### PR TITLE
Change download link to latest release

### DIFF
--- a/data/urls.json
+++ b/data/urls.json
@@ -1,6 +1,6 @@
 {
 	"documentation":  "https://github.com/secdec/codepulse/wiki",
-	"download":  "https://github.com/secdec/codepulse/releases/tag/v1.1.2",
+	"download":  "https://github.com/secdec/codepulse/releases/latest",
 	"owasp_project": "https://www.owasp.org/index.php/OWASP_Code_Pulse_Project",
 	"secdec": "http://securedecisions.com/",
 	"avi": "http://www.avi.com/",


### PR DESCRIPTION
Download link was outdated. I changed it to point to the latest release rather than a hard coded release.